### PR TITLE
fix: PrimeVue and Tailwind CSS conflicts

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700&display=swap"
       rel="stylesheet" />
   </head>
-  <body>
+  <body class="primevue">
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "lint-staged": "^13.0.2",
         "markdownlint-cli2": "^0.4.0",
         "postcss": "^8.4.13",
+        "postcss-prefix-selector": "^1.16.0",
         "prettier": "^2.5.1",
         "stylelint": "^14.8.0",
         "stylelint-config-prettier": "^9.0.3",
@@ -6097,6 +6098,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-prefix-selector": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
+      "integrity": "sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": ">4 <9"
       }
     },
     "node_modules/postcss-resolve-nested-selector": {
@@ -12890,6 +12900,13 @@
       "requires": {
         "postcss-selector-parser": "^6.0.6"
       }
+    },
+    "postcss-prefix-selector": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
+      "integrity": "sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==",
+      "dev": true,
+      "requires": {}
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lint-staged": "^13.0.2",
     "markdownlint-cli2": "^0.4.0",
     "postcss": "^8.4.13",
+    "postcss-prefix-selector": "^1.16.0",
     "prettier": "^2.5.1",
     "stylelint": "^14.8.0",
     "stylelint-config-prettier": "^9.0.3",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,5 +4,14 @@ module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
+    "postcss-prefix-selector": {
+      prefix: ".primevue",
+      transform: (prefix, selector) => {
+        if (selector.startsWith(".p-")) {
+          return `${prefix} ${selector}`;
+        }
+        return selector;
+      },
+    },
   },
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

We are giving PrimeVue styles priority over Tailwind with a higher CSS specificity.

### Usage

It is automatically applied with a PostCSS plugin.

### Why is it needed

A lot of styling issues because of Tailwind overriding PrimeVue styles due to a higher specificity with their preflight.
